### PR TITLE
fix(.gitignore) ++ .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.python-version
+
 .DS_Store
 .ipynb_checkpoints/
 __pycache__


### PR DESCRIPTION
考虑到涉及本地 Python 运行时环境, 
一般都是通过 PyEnv 等工具来管理,
所以, 先追加对应 配置文件 的忽略, 以免其它读者将自己本地特殊的配置文件也 push 上来.