### PR TITLE
修改两处字符

### DIFF
--- a/Part.1.D.preparation.for.reading.ipynb
+++ b/Part.1.D.preparation.for.reading.ipynb
@@ -133,9 +133,9 @@
     "\n",
     "同样，你可以暂时忽略它们的意义和工作原理；只需要知道因为有它们在，所以每次执行那个单元格中的代码会有不同的结果就可以了。\n",
     "\n",
-    "如果你不是直接在网站上浏览这本“书”、或者是在阅读印刷版，而是在本地自己搭建 Jupyterlab 环境使用，那么请参阅附录《[Jupyterlab 的安装与配置](z-appendix.jupyter-installation-and-setup.ipynb)》。\n",
+    "如果你不是直接在网站上浏览这本“书”、或者是在阅读印刷版，而是在本地自己搭建 Jupyterlab 环境使用，那么请参阅附录《[Jupyterlab 的安装与配置](T-appendix.jupyter-installation-and-setup.ipynb)》。\n",
     "\n",
-    "> **注意**：尤其需要仔细看看《[Jupyterlab 的安装与配置](z-appendix.jupyter-installation-and-setup.ipynb)》的《关于 Jupyter lab themes》这一小节 —— 否则，阅读体验会有很大差别。\n",
+    "> **注意**：尤其需要仔细看看《[Jupyterlab 的安装与配置](T-appendix.jupyter-installation-and-setup.ipynb)》的《关于 Jupyter lab themes》这一小节 —— 否则，阅读体验会有很大差别。\n",
     "\n",
     "另外，如果你使用的是 [nteract](https://nteract.io) 桌面版 App 浏览 `.ipynb` 文件，那么有些使用了 `input()` 函数的代码是无法在 nteract 中执行的。"
    ]


### PR DESCRIPTION
将两处`z`改为`T`——即`《[Jupyterlab 的安装与配置](z-appendix.jupyter-installation-and-setup.ipynb)》`修改为`《[Jupyterlab 的安装与配置](T-appendix.jupyter-installation-and-setup.ipynb)》`，使链接能正确跳转