### PR TITLE
修正链接地址，原地址报404。

### DIFF
--- a/02.proof-of-work.ipynb
+++ b/02.proof-of-work.ipynb
@@ -83,7 +83,7 @@
     "> 1. 注册 [github.com](https://github.com) 帐号 —— 无论如何你都必须有 github 账户；\n",
     "> 2. 使用浏览器访问 [https://github.com/selfteaching/the-craft-of-selfteaching](https://github.com/selfteaching/the-craft-of-selfteaching)；\n",
     "> 3. 在页面右上部找到“Fork”按钮，将该仓库 Fork 到你自己的账户中；\n",
-    "> 4. 使用 `git clone` 命令或者使用 [Desktop for Github](https://desktop.github.com/) 将 [the craft of selfteaching](https://github.com/xiaolai/the-craft-of-selfteaching) 这个你 Fork 过来的仓库克隆到本地；\n",
+    "> 4. 使用 `git clone` 命令或者使用 [Desktop for Github](https://desktop.github.com/) 将 [the craft of selfteaching](https://github.com/selfteaching/the-craft-of-selfteaching) 这个你 Fork 过来的仓库克隆到本地；\n",
     "> 5. 按照 [Jupyterlab 的安装与配置](T-appendix.jupyter-installation-and-setup.ipynb) 的说明在本地搭建好 Jupyterlab —— 如果在 Jupyterlab 中浏览本书的话，其中的所有代码都是可以“当场执行”的，并且，你还可以直接改着玩……\n",
     "> 6. 在阅读过程中，可以不断通过修改文章中的代码作为练习 —— 这样做的结果就是已阅读过的文件会发生变化…… 每读完一章，甚至时时刻刻，你都可以通过 `git commit` 命令向你自己 Fork 过来的仓库提交变化 —— 这就是你的阅读工作证明；\n",
     "> 7. 仓库里有一个目录，`my-notes`，你可以把你在学习过程中写的笔记放在那里；\n",


### PR DESCRIPTION
xiaolai -> selfteaching
访问`https://github.com/xiaolai/the-craft-of-selfteaching`报404，改为`https://github.com/selfteaching/the-craft-of-selfteaching`