### PR TITLE
solve git clone failue/slow problem

### DIFF
--- a/02.proof-of-work.ipynb
+++ b/02.proof-of-work.ipynb
@@ -83,7 +83,7 @@
     "> 1. 注册 [github.com](https://github.com) 帐号 —— 无论如何你都必须有 github 账户；\n",
     "> 2. 使用浏览器访问 [https://github.com/selfteaching/the-craft-of-selfteaching](https://github.com/selfteaching/the-craft-of-selfteaching)；\n",
     "> 3. 在页面右上部找到“Fork”按钮，将该仓库 Fork 到你自己的账户中；\n",
-    "> 4. 使用 `git clone` 命令或者使用 [Desktop for Github](https://desktop.github.com/) 将 [the craft of selfteaching](https://github.com/xiaolai/the-craft-of-selfteaching) 这个你 Fork 过来的仓库克隆到本地；\n",
+    "> 4. 使用 `git clone` 命令或者使用 [Desktop for Github](https://desktop.github.com/) 将 [the craft of selfteaching](https://github.com/xiaolai/the-craft-of-selfteaching) 这个你 Fork 过来的仓库克隆到本地；(如果由于github.com网络连接问题无法下载，可注册登录[码云](https://gitee.com)，先将github代码fork到码云，再直接从码云下载）\n",
     "> 5. 按照 [Jupyterlab 的安装与配置](T-appendix.jupyter-installation-and-setup.ipynb) 的说明在本地搭建好 Jupyterlab —— 如果在 Jupyterlab 中浏览本书的话，其中的所有代码都是可以“当场执行”的，并且，你还可以直接改着玩……\n",
     "> 6. 在阅读过程中，可以不断通过修改文章中的代码作为练习 —— 这样做的结果就是已阅读过的文件会发生变化…… 每读完一章，甚至时时刻刻，你都可以通过 `git commit` 命令向你自己 Fork 过来的仓库提交变化 —— 这就是你的阅读工作证明；\n",
     "> 7. 仓库里有一个目录，`my-notes`，你可以把你在学习过程中写的笔记放在那里；\n",


### PR DESCRIPTION
Add (如果由于github.com网络连接问题无法下载，可注册登录[码云](https://gitee.com)，先将github代码fork到码云，再直接从码云下载）in line 86.
Users may encounter git cloe failue due to the poor internect connection to github in mainland. An option is to fork the reporsity to gitee.com and to download the code from gitee.com which just takes a few seconds. 

git clone error description:
error: RPC failed; curl 56 LibreSSL SSL_read: SSL_ERROR_SYSCALL, errno 54
fatal: The remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed