### PR TITLE
fix python grammar mistake. =+ -> +=

### DIFF
--- a/Part.1.E.6.containers.ipynb
+++ b/Part.1.E.6.containers.ipynb
@@ -726,7 +726,7 @@
     "# 在末尾追加一个列表\n",
     "print()\n",
     "print(a_list)\n",
-    "a_list.extend(c_list)      # 相当于 a_list =+ c_list\n",
+    "a_list.extend(c_list)      # 相当于 a_list += c_list\n",
     "print(a_list)\n",
     "\n",
     "# 在某索引位置插入一个元素\n",


### PR DESCRIPTION
fix python grammar mistake. `=+` -> `+=`