### PR TITLE
fix S.O.L.I.D link format

### DIFF
--- a/Part.3.F.social-selfteaching.ipynb
+++ b/Part.3.F.social-selfteaching.ipynb
@@ -141,7 +141,7 @@
     "> - [MoSCoW method](https://en.wikipedia.org/wiki/MoSCoW_method)\n",
     "> - [Overengineering](https://en.wikipedia.org/wiki/Overengineering)\n",
     "> - [Worse is better](https://en.wikipedia.org/wiki/Worse_is_better)\n",
-    "> - [S.O.L.I.D.](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design))\n",
+    "> - [S.O.L.I.D.](https://en.wikipedia.org/wiki/SOLID)\n",
     "> - [Unix philosophy](https://en.wikipedia.org/wiki/Unix_philosophy)"
    ]
   },


### PR DESCRIPTION
修复现在链接显示问题。现有写法，在GitHub解析后显示不正常，多一个')'。
经过确认，现在wiki使用的链接为：https://en.wikipedia.org/wiki/SOLID。
文中使用的：https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)会自动重定向到该路由。

PS：
如果想用：https://en.wikipedia.org/wiki/SOLID_(object-oriented_design) ，可以使用反斜杠转译才能正常显示：https://en.wikipedia.org/wiki/SOLID_\\(object-oriented_design\\) 。