### PR TITLE
PEP8 代码风格

### DIFF
--- a/Part.1.E.6.containers.ipynb
+++ b/Part.1.E.6.containers.ipynb
@@ -1429,10 +1429,10 @@
     "admins = {'Moose', 'Joker', 'Joker'}\n",
     "moderators = {'Ann', 'Chris', 'Jane', 'Moose', 'Zero'}\n",
     "\n",
-    "v = venn2(subsets = (admins, moderators), set_labels =('admins', 'moderators'))\n",
-    "v.get_label_by_id('11').set_text('\\n'.join(admins&moderators))\n",
-    "v.get_label_by_id('10').set_text('\\n'.join(admins-moderators))\n",
-    "v.get_label_by_id('01').set_text('\\n'.join(admins^moderators))\n",
+    "v = venn2(subsets=(admins, moderators), set_labels=('admins', 'moderators'))\n",
+    "v.get_label_by_id('11').set_text('\\n'.join(admins & moderators))\n",
+    "v.get_label_by_id('10').set_text('\\n'.join(admins - moderators))\n",
+    "v.get_label_by_id('01').set_text('\\n'.join(admins ^ moderators))\n",
     "\n",
     "plt.show()"
    ]


### PR DESCRIPTION
1. 逻辑操作符两侧要加空格
2. 在关键字参数和默认参数值中的 = 两侧不加空格