### PR TITLE
Better example in Part.3.B.4.regex.ipynb

### DIFF
--- a/Part.3.B.4.regex.ipynb
+++ b/Part.3.B.4.regex.ipynb
@@ -460,9 +460,9 @@
     "\n",
     "`$` 匹配被搜索字符串的结束位置；\n",
     "\n",
-    "`\\b` 匹配单词的边界；[`er\\b`](https://regexper.com#er%5Cb)，能匹配 `wonderer` 中的 `er`，却不能匹配 `error` 中的 `er`；\n",
+    "`\\b` 匹配单词的边界；[`er\\b`](https://regexper.com#er%5Cb)，能匹配 `coder` 中的 `er`，却不能匹配 `error` 中的 `er`；\n",
     "\n",
-    "`\\B` 匹配非单词边界；[`er\\B`](https://regexper.com#er%5CB)，能匹配 `error` 中的 `er`，却不能匹配 `wonderer` 中的 `er`。"
+    "`\\B` 匹配非单词边界；[`er\\B`](https://regexper.com#er%5CB)，能匹配 `error` 中的 `er`，却不能匹配 `coder` 中的 `er`。"
    ]
   },
   {


### PR DESCRIPTION
## Change
wonderer -> coder

## Reason
`er\B` 能够匹配wonderer中间的`er`

![image](https://user-images.githubusercontent.com/12432409/54579123-0773c980-4a3d-11e9-97d4-2bbaf95713b9.png)

换成 `coder` 可以消除歧义
