### PR TITLE
Fix: 修复人类发展指数（Human Development Index）因为没有使用blob导致链接404问题、新增原文链接。

### DIFF
--- a/Part.1.A.better.teachyourself.ipynb
+++ b/Part.1.A.better.teachyourself.ipynb
@@ -181,8 +181,11 @@
     "# plt.savefig('human-development-index-china-1870-2015.png', transparent=True)\n",
     "plt.show()\n",
     "\n",
+    "# link:\n",
+    "# https://ourworldindata.org/human-development-index\n",
+    "\n",
     "# data from:\n",
-    "# https://ourworldindata.org/957e133e-f3e9-4bf2-9627-dbf30ebc9b4d"
+    "# blob:https://ourworldindata.org/44b6da71-f79e-42ab-ab37-871e4bd256e9"
    ]
   },
   {
@@ -326,7 +329,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.2"
   },
   "nteract": {
    "version": "nteract-on-jupyter@2.0.3"


### PR DESCRIPTION
### 问题：
原文[数据链接](https://ourworldindata.org/957e133e-f3e9-4bf2-9627-dbf30ebc9b4d)点击时出现 404 页面。

改为从[原文](https://ourworldindata.org/human-development-index)中的图表位找到 Data 的 csv 链接重写；

怕链接**再次失效**，附[原文地址](https://ourworldindata.org/human-development-index)。