### PR TITLE
fine tune on format by correcting ‘empty sequences’

### DIFF
--- a/Part.1.E.2.values-and-their-operators.ipynb
+++ b/Part.1.E.2.values-and-their-operators.ipynb
@@ -655,7 +655,7 @@
     "> > * zero of any numeric type: `0`, `0.0`, `0j`, `Decimal(0)`, `Fraction(0, 1)`\n",
     "> > * empty sequences and collections: `''`, `()`, `[]`, `{}`, `set()`, `range(0)`\n",
     "\n",
-    "所以，`'Python'` 是个非空的字符串，即，不属于是‘empty sequences’，所以它不被认为是 `False`，即，它的布尔值是 `True`\n",
+    "所以，`'Python'` 是个非空的字符串，即，不属于是 `empty sequences` ，所以它不被认为是 `False`，即，它的布尔值是 `True`\n",
     "\n",
     "于是，这么理解就轻松了：\n",
     "\n",


### PR DESCRIPTION
fine tune on format by correcting ‘empty sequences’ to `empty sequences` in Part1.E.2