### PR TITLE
fix[Part 1.E.2]modified a code block

### DIFF
--- a/Part.1.E.2.values-and-their-operators.ipynb
+++ b/Part.1.E.2.values-and-their-operators.ipynb
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -162,7 +162,27 @@
        "3.14159"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.0"
+      ]
+     },
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -173,7 +193,7 @@
     "\n",
     "abs(-3.14159)\n",
     "int(abs(-3.14159))\n",
-    "float(abs(-3.14159))"
+    "float(int(abs(-3.14159)))"
    ]
   },
   {


### PR DESCRIPTION
`float(abs(-3.14159))` -> `float(int(abs(-3.14159)))`

根据描述：

> 比如，`abs()` 函数，就会返回传递给它的_值_的*绝对值*；`int()` 函数，会将传递给它的值的小数部分砍掉；`float()` 接到整数参数之后，会返回这个整数的浮点数形式。

代码应该是如上那样的——因为 float() 中应该是整数参数。