### PR TITLE
1059行 调用任意关键字参数时应该使用**

### DIFF
--- a/Part.3.B.3.decorator-iterator-generator.ipynb
+++ b/Part.3.B.3.decorator-iterator-generator.ipynb
@@ -1056,7 +1056,7 @@
     "        print(f\"Trace: You've called a function: {func.__name__}(),\",\n",
     "              f\"with args: {args}; kwargs: {kwargs}\")\n",
     "    \n",
-    "        original_result = func(*args, *kwargs)\n",
+    "        original_result = func(*args, **kwargs)\n",
     "        print(f\"Trace: {func.__name__}{args} returned: {original_result}\")\n",
     "        return original_result\n",
     "    return wrapper\n",


### PR DESCRIPTION
1059行 original_result = func(*args, *kwargs) -> original_result = func(*args, **kwargs)，调用任意关键字参数时用该使用**