### PR TITLE
Edit example according to meaning

### DIFF
--- a/Part.1.E.2.values-and-their-operators.ipynb
+++ b/Part.1.E.2.values-and-their-operators.ipynb
@@ -937,7 +937,7 @@
     {
      "data": {
       "text/plain": [
-       "True"
+       "False"
       ]
      },
      "execution_count": 16,
@@ -946,7 +946,7 @@
     }
    ],
    "source": [
-    "True or 'Python'"
+    "not 'Python'"
    ]
   },
   {

--- a/markdown/Part.1.E.2.values-and-their-operators.md
+++ b/markdown/Part.1.E.2.values-and-their-operators.md
@@ -422,10 +422,10 @@ math.sin(5)
 
 
 ```python
-True or 'Python'
+not 'Python'
 ```
 
-    True
+    False
 
 
 这是因为 Python 将 `True` 定义为：


### PR DESCRIPTION
这里[原文](https://github.com/selfteaching/the-craft-of-selfteaching/blob/master/markdown/Part.1.E.2.values-and-their-operators.md#%E5%85%B3%E4%BA%8E%E5%B8%83%E5%B0%94%E5%80%BC%E7%9A%84%E8%A1%A5%E5%85%85)使用的这个例子
```python
True or 'Python'
```
其结果`True`和`'Python'`没有什么关系，个人认为应该是笔误，根据上下文修改了一下例子。