### PR TITLE
a_list = a_list.sort() 替换为 a_list.sort()

### DIFF
--- a/Part.1.E.6.containers.ipynb
+++ b/Part.1.E.6.containers.ipynb
@@ -644,7 +644,7 @@
    ],
    "source": [
     "a_list = [1, 'a', 'c']\n",
-    "a_list = a_list.sort() # 这一句会报错"
+    "a_list.sort() # 这一句会报错"
    ]
   },
   {


### PR DESCRIPTION
虽然这句没有语法问题，但是：
（当 sort() 方法没法被 a_list 执行的情况下，会报错，没问题）；
当 sort() 方法被 a_list 正确执行的情况下 a_list 执行 sort() 方法后的返回值为 None ，将 None 赋值给 a_list 是没有必要的，且会让 a_list 变量变成 None。
建议直接将 a_list = a_list.sort() 替换为 a_list.sort()