### PR TITLE
随意 -> 任意

### DIFF
--- a/Part.2.D.2-aargs.ipynb
+++ b/Part.2.D.2-aargs.ipynb
@@ -20,9 +20,9 @@
    "source": [
     "如果你在定义参数的时候，在一个_位置参数_（Positional Arguments）前面标注了星号，`*`，那么，这个位置参数可以接收一系列值，在函数内部可以对这一系列值用 `for ... in ...` 循环进行逐一的处理。\n",
     "\n",
-    "带一个星号的参数，英文名称是 “Arbitrary Positional Arguments”，姑且翻译为 “随意的位置参数”。\n",
+    "带一个星号的参数，英文名称是 “Arbitrary Positional Arguments”，姑且翻译为 “任意的位置参数”。\n",
     "\n",
-    "还有带两个星号的参数，一会儿会讲到，英文名称是 “Arbitrary Keyword Arguments”，姑且翻译为 “随意的关键字参数”。\n",
+    "还有带两个星号的参数，一会儿会讲到，英文名称是 “Arbitrary Keyword Arguments”，姑且翻译为 “任意的关键字参数”。\n",
     "\n",
     "> 有些中文书籍把 “Arbitrary Positional Arguments” 翻译成 “可变位置参数”。事实上，在这样的地方，无论怎样的中文翻译都是令人觉得非常吃力的。前面的这个翻译还好了，我还见过把 “Arbitrary Keyword Arguments” 翻译成 “武断的关键字参数” 的 —— 我觉得这样的翻译肯定会使读者产生说不明道不白的疑惑。\n",
     ">\n",


### PR DESCRIPTION
商榷：
“随意”和“任意”虽然意思基本相同，但在语感上似乎不太一样。
“随意”易引起“随便”的联想，带有一种“可以马虎处理”的感觉，不太好。
“任意”的感觉好一些，更偏向“按照自己的需要决定”的意思。
以上为个人意见。