### PR TITLE
improve example for 'raw' and 'presentation'

### DIFF
--- a/Part.1.E.5.strings.ipynb
+++ b/Part.1.E.5.strings.ipynb
@@ -548,7 +548,7 @@
     }
    ],
    "source": [
-    "s = \"He said, it's fine.\" # raw\n",
+    "s = \"He said, it\'s fine.\" # raw\n",
     "print(s)                   # presentation"
    ]
   },


### PR DESCRIPTION
improve example for 'raw' and 'presentation', added '\' to show difference between 'raw' and 'presentation'. outcome is same.