### PR TITLE
by-zhenggenwang

### DIFF
--- a/Part.3.B.3.decorator-iterator-generator.ipynb
+++ b/Part.3.B.3.decorator-iterator-generator.ipynb
@@ -1037,15 +1037,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace: You've called a function: say_hi(), with args: ('Hello', 'Jack'); kwargs: {}\n",
-      "Trace: say_hi('Hello', 'Jack') returned: Hello! Jack.\n",
+      "Trace: You've called a function: say_hi(), with args: ('Hello',); kwargs: {'name': 'Jack'}\n",
+      "Trace: say_hi('Hello',) returned: Hello! Jack.\n",
       "Hello! Jack.\n"
      ]
     }
@@ -1065,7 +1065,7 @@
     "def say_hi(greeting, name=None):\n",
     "    return greeting + '! ' + name + '.'\n",
     "\n",
-    "print(say_hi('Hello', 'Jack'))"
+    "print(say_hi('Hello', name='Jack'))"
    ]
   },
   {


### PR DESCRIPTION
在 Part.3.B.3.decorator-iterator-generator 这一节，最后一个讲解Decorator用处的例子，有一处错误：

print(say_hi('Hello', 'Jack')) 语句 应该写成 print(say_hi('Hello', name='Jack'))，这样 **kwargs 才会起到作用，旧的写法的输出结果是：Trace: You've called a function: say_hi(), with args: ('Hello', 'Jack'); kwargs: {}，关键字参数为空，正确写法的输出结果是：Trace: You've called a function: say_hi(), with args: ('Hello',); kwargs: {'name': 'Jack'}，这种情况下 **kwargs 的输出才不会为空。