### PR TITLE
 'Jack' → name = 'Jack'

### DIFF
--- a/Part.3.B.3.decorator-iterator-generator.ipynb
+++ b/Part.3.B.3.decorator-iterator-generator.ipynb
@@ -1030,15 +1030,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace: You've called a function: say_hi(), with args: ('Hello', 'Jack'); kwargs: {}\n",
-      "Trace: say_hi('Hello', 'Jack') returned: Hello! Jack.\n",
+      "Trace: You've called a function: say_hi(), with args: ('Hello',); kwargs: {'name': 'Jack'}\n",
+      "Trace: say_hi('Hello',) returned: Hello! Jack.\n",
       "Hello! Jack.\n"
      ]
     }
@@ -1058,7 +1058,7 @@
     "def say_hi(greeting, name=None):\n",
     "    return greeting + '! ' + name + '.'\n",
     "\n",
-    "print(say_hi('Hello', 'Jack'))"
+    "print(say_hi('Hello', name = 'Jack'))"
    ]
   },
   {


### PR DESCRIPTION
原表达没毛病。
只不过这样一改，那个 `kwargs: {}` 输出就不用空着了~