### PR TITLE
Part.1.E.5中1.8.7.1. 使用 str.format() 示例程序最后一行注释的str.fomrat()单词拼写错误

### DIFF
--- a/Part.1.E.5.strings.ipynb
+++ b/Part.1.E.5.strings.ipynb
@@ -3,6 +3,12 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    },
     "toc-hr-collapsed": false
    },
    "source": [
@@ -11,14 +17,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "在任何一本编程书籍之中，关于字符串的内容总是很长 —— 就好像每本英语语法书中，关于动词的内容总是占全部内容的至少三分之二。这也没什么办法，因为处理字符串是计算机程序中最普遍的需求 —— 因为程序的主要功能就是完成人机交互，人们所用的就是字符串而不是二进制数字。"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "在计算机里，所有的东西最终都要被转换成数值。又由于计算机靠的是电路，所以，最终只能处理 `1` 和 `0`，于是，最基本的数值是二进制；于是，连整数、浮点数字，都要最终转换成二进制数值。这就是为什么在所有编程语言中 `1.1 + 2.2` 并不是你所想象的 `3.3` 的原因。"
    ]
@@ -26,7 +46,15 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -45,7 +73,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "因为最终所有的值都要转换成二进制 —— 这时候，小数的精度就有损耗，多次浮点数字转换成二进制相互运算之后再从二进制转换为十进制之后返回的结果，精度损耗就更大了。因此，在计算机上，浮点数字的精度总有极限。有兴趣进一步可以看看[关于 decimal 模块的文档](https://docs.python.org/3/library/decimal.html)。\n",
     "\n",
@@ -54,14 +89,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "## 字符码表的转换"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "很久以前，计算机的中央处理器最多只能够处理 8 位二进制数值，所以，那时候的计算机只能处理 256 个字符，即，2<sup>8</sup> 个字符。那个时候计算机所使用的码表叫 ASCII。现在计算机的中央处理器，大多是 64 位的，所以可以使用 2<sup>64</sup> 容量的码表，叫做 [Unicode](https://zh.wikipedia.org/wiki/Unicode)。随着多年的收集，2018 年 6 月 5 日公布的 `11.0.0` 版本已经包含了 13 万个字符 —— 突破 10 万字符是在 2005 年<a href='#fn1' name='fn1b'><sup>[1]</sup></a>。\n",
     "\n",
@@ -72,7 +121,15 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -132,6 +189,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -143,7 +201,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "标示一个字符串，有 4 种方式，用单引号、用双引号，用三个单引号或者三个双引号："
    ]
@@ -151,7 +216,15 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -171,7 +244,15 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -191,7 +272,15 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -217,7 +306,15 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -241,7 +338,15 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -268,6 +373,12 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    },
     "toc-hr-collapsed": true
    },
    "source": [
@@ -276,7 +387,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "由数字构成的字符串，可以被转换成数值，转换整数用 `int()`，转换浮点数字用 `float()`。\n",
     "\n",
@@ -288,7 +406,15 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -333,7 +459,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "`input()` 这个内建函数的功能是接收用户的键盘输入，而后将其作为字符串返回。它可以接收一个字符串作为参数，在接收用户键盘输入之前，会把这个参数输出到屏幕，作为给用户的提示语。这个参数是可选参数，直接写 `input()`，即，没有提供参数，那么它在要求用户输入的时候，就没有提示语。\n",
     "\n",
@@ -343,7 +476,15 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdin",
@@ -374,7 +515,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "要改成这样才可能行：\n",
     "为什么是可能行而不是一定行？如果用户 `input` 键盘输入的是 `eighteen` 或者 ` 十八 ` 等，依然会导致 `int()` 失败并得到 `ValueError` 的报错。用户输入的不可控，可能会导致千奇百怪的报错。但在这里，我们先简化处理，在引导语中加入一个正确的示例并默认用户会按引导语正确输入。"
@@ -383,7 +531,15 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdin",
@@ -412,21 +568,42 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "**注意**：如果你用来浏览当前 `.ipynb` 文件的是那个桌面 App [Nteract](https://nteract.io/)，它目前不支持 input() 这个函数的调用……"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "## 转义符"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "有一个重要的字符，叫做 “转义符”，`\\`，也有的地方把它称为 “脱字符”，因为它的英文原文是 _Escaping Character_。它本身不被当作字符，你要想在字符串里含有这个字符，得这样写 `\\\\`："
    ]
@@ -434,7 +611,15 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -454,7 +639,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "ename": "SyntaxError",
@@ -471,7 +664,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "上面这一行报错信息是 `SyntaxError: EOL while scanning string literal`。这是因为 `\\'` 表示的是单引号字符 `'`（Literal）—— 是可被输出到屏幕的 `'`，而不是用来标示字符串的那个 `'` —— 别急，无论哪个初学者第一次读到前面的句子都觉得有点莫名其妙…… —— 于是，Python 编译器扫描这个 “字符串” 的时候，还没找到标示字符串末尾的另外一个 `'` 的时候就读到了 `EOL`（End Of Line）。\n",
     "\n",
@@ -481,7 +681,15 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "ename": "SyntaxError",
@@ -498,7 +706,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "于是你就得用转义符 `\\`："
    ]
@@ -506,7 +721,15 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -553,7 +776,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "转义符号 `\\` 的另外两个常用形式是和 `t`、`n` 连起来用，`\\t` 代表制表符（就是用 TAB `⇥` 键敲出来的东西），`\\n` 代表换行符（就是用 Enter `⏎` 敲出来的东西）。\n",
     "\n",
@@ -567,7 +797,15 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -584,7 +822,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "以后有时间去看看这两个内建函数，能了解更多细节：\n",
     "> * **ascii**(_object_) https://docs.python.org/3/library/functions.html#ascii\n",
@@ -595,6 +840,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -606,7 +852,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "字符串可以用空格 `' '` 或者 `+` 拼接："
    ]
@@ -614,7 +867,15 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -634,7 +895,15 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -653,7 +922,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "字符串还可以与整数倍操作符 `*` 操作，`'Ha' * 3` 的意思是说，把字符串 `'Ha'` 复制三遍："
    ]
@@ -661,7 +937,15 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -681,7 +965,15 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -700,7 +992,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "字符串还可以用 `in` 和 `not in` 操作符 —— 看看某个字符或者字符串是否被包含在某个字符串中，返回的是布尔值："
    ]
@@ -708,7 +1007,15 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -727,14 +1034,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "## 字符串的索引"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "字符串是由一系列的字符构成的。在 Python 当中，有一个容器（Container）的概念，这个概念前面提到过，后面还会深入讲解。现在需要知道的是，字符串是容器的一种；容器可分为两种，有序的和无序的 —— 字符串属于**有序容器**。\n",
     "\n",
@@ -750,7 +1071,15 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -773,7 +1102,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "对于有序容器中的元素 —— 字符串就是字符的有序容器 —— 由于它们是有索引的，所以我们可以根据索引提取容器中的值，你可以把 `[]` 当作是有序容器的操作符之一，我们姑且将其称为 “*索引操作符*”。注意以下代码第 3 行中，`s` 后面的 `[]`，以及里面的变量 `i`："
    ]
@@ -781,7 +1117,15 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -808,7 +1152,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "我们可以使用*索引操作符*根据*索引***提取**字符串这个*有序容器*中的*一个或多个元素*，即，其中的字符或字符串。这个 “提取” 的动作有个专门的术语，叫做 “Slicing”（切片）。索引操作符 `[]` 中可以有一个、两个或者三个整数参数，如果有两个参数，需要用 `:` 隔开。它最终可以写成以下 4 种形式：\n",
     "\n",
@@ -824,7 +1175,15 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -893,6 +1252,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -906,6 +1266,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -918,7 +1279,15 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1025,6 +1394,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1039,6 +1409,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1062,6 +1433,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1074,7 +1446,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "转换字符串大小写的是 `str.upper()`、`str.lower()` 和 `str.swapcase()`，以及 `str.casefold()`；另外，还有专门针对行首字母大写的 `str.capitalize()` 和针对每个词的首字母大写的 `str.title()`："
    ]
@@ -1082,7 +1461,15 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1121,7 +1508,15 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1228,7 +1623,15 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1263,7 +1666,15 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1307,6 +1718,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1319,7 +1731,15 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1344,6 +1764,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1355,7 +1776,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "让我们从 `str.count()` 这个搜寻子字符串出现次数的 Method（即，`str` 这个 `Class` 中定义的函数）开始。\n",
     "\n",
@@ -1386,7 +1814,15 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1432,7 +1868,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "以下是 `str` 的搜索与替换的 Methods：`str.find()`, `str.rfind()`, `str.index()` 的示例："
    ]
@@ -1440,7 +1883,15 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1587,7 +2038,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "`str.startswith()` 和 `str.endswith()` 是用来判断一个*字符串*是否以某个*子字符串*起始或者结束的："
    ]
@@ -1595,7 +2053,15 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1636,7 +2102,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "为了找到位置而进行搜索之前，你可能经常需要事先确认需要寻找的字符串在寻找对象中是否存在，这个时候，可以用 `in` 操作符："
    ]
@@ -1644,7 +2117,15 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1663,7 +2144,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "能搜索，就应该能替换 —— `str.replace()`，它的函数说明是这样的：\n",
     "\n",
@@ -1675,7 +2163,15 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1701,6 +2197,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1717,7 +2214,15 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1754,6 +2259,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1765,7 +2271,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "> `str.strip([chars])`\n",
     "\n",
@@ -1778,6 +2291,7 @@
    "metadata": {
     "button": false,
     "collapsed": true,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1816,7 +2330,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "但是，如果给定了一个字符串作为参数，那么参数字符串中的所有字母都会被当做需要从首尾剔除的对象："
    ]
@@ -1824,7 +2345,15 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1869,7 +2398,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "还可以只对左侧处理，`str.lstrip()` 或者只对右侧处理，`str.rstrip()`"
    ]
@@ -1880,6 +2416,7 @@
    "metadata": {
     "button": false,
     "collapsed": true,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1934,6 +2471,7 @@
    "metadata": {
     "button": false,
     "collapsed": true,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1986,6 +2524,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1997,7 +2536,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "在计算机里，数据一般保存在文件之中。计算机擅长处理的是 “格式化数据”，即，这些数据按照一定的格式排列 —— 电子表格、数据库，就是一种保存方式。Microsoft 的 Excel 和 Apple 的 Numbers，都可以将表格导出为 `.csv` 文件。这是文本文件，里面的每一行可能由多个数据构成，数据之间用 `,`（或 `;`、`\\t`）分隔：\n",
     "\n",
@@ -2021,7 +2567,15 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2064,7 +2618,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "`str.split()`, 是将一个字符串，根据分隔符进行拆分：\n",
     "\n",
@@ -2074,7 +2635,15 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2173,6 +2742,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -2184,7 +2754,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "`str.join()` 是将来非常常用的，它的官方文档说明却很少：\n",
     "\n",
@@ -2198,7 +2775,15 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2221,6 +2806,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -2232,7 +2818,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "将字符串居中放置 —— 前提是设定整行的长度：\n",
     "\n",
@@ -2246,6 +2839,8 @@
    "execution_count": 42,
    "metadata": {
     "button": false,
+    "collapsed": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -2321,7 +2916,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "将字符串靠左或者靠右对齐放置：\n",
     "\n",
@@ -2331,7 +2933,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "另外，还有个字符串 Method 是，将字符串转换成左侧由 `0` 填充的指定长度字符串。例如，这在批量生成文件名的时候就很有用……"
    ]
@@ -2339,7 +2948,15 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2368,6 +2985,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -2380,21 +2998,42 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "所谓对字符串进行格式化，指的是将特定变量插入字符串特定位置的过程。常用的 Methods 有两个，一个是 `str.format()`，另外一个是 `f-string`。"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "#### 使用 str.format() "
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "这个 Method 的[官方文档说明](https://docs.python.org/3/library/stdtypes.html#str.format)，你现在是死活看不懂的：\n",
     "\n",
@@ -2413,7 +3052,15 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2465,20 +3112,34 @@
     "# \"%s is %d years old.\" % (name, age)\n",
     "# 上一行这是兼容 Python 2 的老式写法，可以从此忽略……\n",
     "\n",
-    "# str.fomrat() 里可以直接写表达式……\n",
+    "# str.format() 里可以直接写表达式……\n",
     "'{} is a grown up? {}'.format(name, age >= 18)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "#### 使用 f-string"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "_f-string_ 与 `str.format()` 的功用差不多，只是写法简洁一些 —— 在字符串标示之前加上一个字母 `f`："
    ]
@@ -2486,7 +3147,15 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2524,7 +3193,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "只不过，str.format() 的用法中，索引顺序可以任意指定，于是相对更为灵活，下面的例子只是为了演示参数位置可以任意指定："
    ]
@@ -2532,7 +3208,15 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2555,6 +3239,7 @@
    "cell_type": "markdown",
    "metadata": {
     "button": false,
+    "deletable": true,
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -2567,7 +3252,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "字符串还有一系列的 Methods，返回的是布尔值，用来判断字符串的构成属性："
    ]
@@ -2575,7 +3267,15 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "collapsed": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2648,14 +3348,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "## 总结"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "这一章节显得相当繁杂。然而，这一章和下一章（关于容器），都是 “用来锻炼自己耐心的好材料”……\n",
     "\n",
@@ -2673,14 +3387,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "## 为什么数值没有像字符串值这样详细论述？"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "上一章中，我们概括地讲了各种类型的值的运算。而后并没有继续深入讲解数字的运算，而是直接 “跳” 到了这一章关于字符串的内容。其实，只要一张表格和一个列表就足够了（因为之前零零散散都讲过）：\n",
     "\n",
@@ -2719,7 +3447,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "button": false,
+    "deletable": true,
+    "new_sheet": false,
+    "run_control": {
+     "read_only": false
+    }
+   },
    "source": [
     "-----\n",
     "**脚注**\n",


### PR DESCRIPTION
Part.1.E.5中1.8.7.1. 使用 str.format() 示例程序 最后一行注释的str.fomrat()单词拼写错误，应该为 str.format() 
@xiaolai 