### PR TITLE
addOutputOfPrintOfEscapingChar

### DIFF
--- a/Part.1.E.5.strings.ipynb
+++ b/Part.1.E.5.strings.ipynb
@@ -287,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -296,7 +296,7 @@
        "3"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -306,7 +306,7 @@
        "3.0"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -316,7 +316,7 @@
        "'3.1415926'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -433,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -442,13 +442,21 @@
        "'\\\\'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\\\n"
+     ]
     }
    ],
    "source": [
-    "'\\\\'"
+    "'\\\\'\n",
+    "print('\\\\')"
    ]
   },
   {
@@ -461,7 +469,7 @@
      "evalue": "EOL while scanning string literal (<ipython-input-10-d44a383620ab>, line 1)",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-10-d44a383620ab>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    '\\'\u001b[0m\n\u001b[0m       ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m EOL while scanning string literal\n"
+      "\u001b[1;36m  File \u001b[1;32m\"<ipython-input-10-d44a383620ab>\"\u001b[1;36m, line \u001b[1;32m1\u001b[0m\n\u001b[1;33m    '\\'\u001b[0m\n\u001b[1;37m       ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m EOL while scanning string literal\n"
      ]
     }
    ],

--- a/markdown/Part.1.E.5.strings.md
+++ b/markdown/Part.1.E.5.strings.md
@@ -164,9 +164,11 @@ else:
 
 ```python
 '\\'
+print('\\')
 ```
 
     '\\'
+    \
 
 ```python
 '\'


### PR DESCRIPTION
第二次提交这个点的修改建议（改）：

增加转义字符 ```\``` 的 print 输出，增加实际表现的理解。

如果只有原始的结果输出，转义字符的不表现的特征是无法观察到的，新手会以为都是一样的字符。

增加 print() 的输出展示，可以帮助理解转义字符的“非显示”特征。