### PR TITLE
PR_7_addExampleOfFormat

### DIFF
--- a/Part.1.E.5.strings.ipynb
+++ b/Part.1.E.5.strings.ipynb
@@ -2455,6 +2455,8 @@
     "'{} is {} years old.'.format(name, age)\n",
     "# 不写占位符索引就默认每个占位符的索引从第一个开始是 0, 1, 2 ...（占位符数量 - 1)\n",
     "# '{} {}'.format(a, b) 和 '{0} {1}'.format(a, b) 是一样的。\n",
+    "'{1} is {0} years old.'.format(name, age)\n",
+    "# '{1} {0}'.format(a, b) 和 '{} {}'.format(a, b) 是不一样的，前者人为干预了默认排列顺序。\n",
     "\n",
     "# '{0} is {2} years old.'.format(name, age)\n",
     "# 这一句会报错，因为 2 超出实际参数索引极限\n",

--- a/markdown/Part.1.E.5.strings.md
+++ b/markdown/Part.1.E.5.strings.md
@@ -880,6 +880,8 @@ age = 25
 '{} is {} years old.'.format(name, age)
 # 不写占位符索引就默认每个占位符的索引从第一个开始是 0, 1, 2 ...（占位符数量 - 1)
 # '{} {}'.format(a, b) 和 '{0} {1}'.format(a, b) 是一样的。
+'{1} is {0} years old.'.format(name, age)
+# '{1} {0}'.format(a, b) 和 '{} {}'.format(a, b) 是不一样的，前者人为干预了默认排列顺序。
 
 # '{0} is {2} years old.'.format(name, age)
 # 这一句会报错，因为 2 超出实际参数索引极限


### PR DESCRIPTION
增加一个 format() 的反例，来做出比较，让读者更好理解索引的顺序作用。

 添加如下内容：

```
'{1} is {0} years old.'.format(name, age)
# '{1} {0}'.format(a, b) 和 '{} {}'.format(a, b) 是不一样的，前者人为干预了默认排列顺序。
```