### PR TITLE
从目录引入模块需目录下包含 “__init__.py” 文件

### DIFF
--- a/Part.2.D.6-modules.ipynb
+++ b/Part.2.D.6-modules.ipynb
@@ -342,7 +342,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "注意，如果当前目录中并没有 `mycode.py` 这个文件，那么，`mycode` 会被当作目录名再被尝试一次，如果当前目录内，有个叫做 `mycode` 的目录（或称文件夹），那么，`from mycode import *` 的作用就是把 `mycode` 这个文件夹中的所有 `.py` 文件全部导入……\n",
+    "注意，如果当前目录中并没有 `mycode.py` 这个文件，那么，`mycode` 会被当作目录名再被尝试一次，如果当前目录内，有个叫做 `mycode` 的目录（或称文件夹）且该目录下同时要存在 [`__init__.py`](https://docs.python.org/3/reference/import.html#regular-packages) 这个文件（通常为空文件，用于标识本目录形成一个包含多个模块的 **包**（[packages](https://docs.python.org/3/reference/import.html#regular-packages)），它们处在一个独立的 **命名空间**（[namespace](https://docs.python.org/3/glossary.html#term-namespace-package)）），那么，`from mycode import *` 的作用就是把 `mycode` 这个文件夹中的所有 `.py` 文件全部导入……\n",
     "\n",
     "如果我们想要导入 `foo` 这个目录中的 `bar.py` 这个模块文件，那么，可以这么写：\n",
     "\n",

--- a/Part.2.D.6-modules.ipynb
+++ b/Part.2.D.6-modules.ipynb
@@ -342,7 +342,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "注意，如果当前目录中并没有 `mycode.py` 这个文件，那么，`mycode` 会被当作目录名再被尝试一次，如果当前目录内，有个叫做 `mycode` 的目录（或称文件夹）且该目录下同时要存在 [`__init__.py`](https://docs.python.org/3/reference/import.html#regular-packages) 这个文件（通常为空文件，用于标识本目录形成一个包含多个模块的 **包**（[packages](https://docs.python.org/3/reference/import.html#regular-packages)），它们处在一个独立的 **命名空间**（[namespace](https://docs.python.org/3/glossary.html#term-namespace-package)）），那么，`from mycode import *` 的作用就是把 `mycode` 这个文件夹中的所有 `.py` 文件全部导入……\n",
+    "注意，如果当前目录中并没有 `mycode.py` 这个文件，那么，`mycode` 会被当作目录名再被尝试一次 —— 如果当前目录内，有个叫做 `mycode` 的目录（或称文件夹）且该目录下同时要存在一个 [`__init__.py`](https://docs.python.org/3/reference/import.html#regular-packages) 文件（通常为空文件，用于标识本目录形成一个包含多个模块的 **包**（[packages](https://docs.python.org/3/reference/import.html#regular-packages)），它们处在一个独立的 **命名空间**（[namespace](https://docs.python.org/3/glossary.html#term-namespace-package)）），那么，`from mycode import *` 的作用就是把 `mycode` 这个文件夹中的所有 `.py` 文件全部导入……\n",
     "\n",
     "如果我们想要导入 `foo` 这个目录中的 `bar.py` 这个模块文件，那么，可以这么写：\n",
     "\n",


### PR DESCRIPTION
补充从目录引入模块的说明：且该目录下同时要存在 [`__init__.py`](https://docs.python.org/3/reference/import.html#regular-packages) 这个文件（通常为空文件，用于标识本目录形成一个包含多个模块的 **包**（[packages](https://docs.python.org/3/reference/import.html#regular-packages)），它们处在一个独立的 **命名空间**（[namespace](https://docs.python.org/3/glossary.html#term-namespace-package)））