### PR TITLE
Update Part.1.E.6.containers.ipynb

### DIFF
--- a/Part.1.E.6.containers.ipynb
+++ b/Part.1.E.6.containers.ipynb
@@ -244,7 +244,7 @@
     "\n",
     "n = 10 \n",
     "\n",
-    "# 生成一个 n 个元素的序列，每个元素是 1~100 之间的随机数\n",
+    "# 生成一个 n 个元素的序列，每个元素是 1~99 的随机数\n",
     "a_list = [random.randrange(1, 100) for i in range(n)]\n",
     "print(f'a_list comprehends {len(a_list)} random numbers: {a_list}')\n",
     "\n",


### PR DESCRIPTION
前面提到 randrange( )包含开始不包含结束，所以上面写1-100之间的随机数不够准确。因为它包含1，不包含100。按照原文会理解为只包2-99的随机数。