### PR TITLE
Update Part.1.G.The-Python-Tutorial-local.ipynb

### DIFF
--- a/Part.1.G.The-Python-Tutorial-local.ipynb
+++ b/Part.1.G.The-Python-Tutorial-local.ipynb
@@ -235,7 +235,7 @@
     "cd ~/Downloads/cpython/Doc/tutorial/ \n",
     "for f in *.rst\n",
     "    do\n",
-    "        rst2ipynb $f -o \"${f/%.rst/.ipynb}\"\n",
+    "        rst2ipynb $f -o ${f/%.rst/.ipynb}\n",
     "    done\n",
     "mkdir ipynbs\n",
     "mv *.ipynb ipynbs/"
@@ -253,7 +253,7 @@
     "function rsti {\n",
     "    for f in *.rst\n",
     "    do\n",
-    "    rst2ipynb $f -o \"${f/%.rst/.ipynb}\"\n",
+    "    rst2ipynb $f -o ${f/%.rst/.ipynb}\n",
     "    done\n",
     "}\n",
     "```\n",


### PR DESCRIPTION
批量转换 rst 至 ipynb
命令 rst2ipynb $f -o “${f/%.rst/.ipynb}”  中的双引号应该去掉，mac环境执行完成之后，转换后生成的ipynb文件名称都带有双引号。