### PR TITLE
Update Part.3.B.3.decorator-iterator-generator.ipynb

### DIFF
--- a/Part.3.B.3.decorator-iterator-generator.ipynb
+++ b/Part.3.B.3.decorator-iterator-generator.ipynb
@@ -1058,7 +1058,7 @@
     "def say_hi(greeting, name=None):\n",
     "    return greeting + '! ' + name + '.'\n",
     "\n",
-    "print(say_hi('Hello', name = 'Jack'))"
+    "print(say_hi('Hello', name='Jack'))"
    ]
   },
   {


### PR DESCRIPTION
关键字参数规范，去掉了等号两端的空格