### PR TITLE
Change the number of slicing method from ”4“ to ”5“

### DIFF
--- a/Part.1.E.5.strings.ipynb
+++ b/Part.1.E.5.strings.ipynb
@@ -810,7 +810,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "我们可以使用*索引操作符*根据*索引**提取**字符串这个*有序容器*中的*一个或多个元素，即，其中的字符或字符串。这个 “提取” 的动作有个专门的术语，叫做 “Slicing”（切片）。索引操作符 `[]` 中可以有一个、两个或者三个整数参数，如果有两个参数，需要用 `:` 隔开。它最终可以写成以下 4 种形式：\n",
+    "我们可以使用*索引操作符*根据*索引**提取**字符串这个*有序容器*中的*一个或多个元素，即，其中的字符或字符串。这个 “提取” 的动作有个专门的术语，叫做 “Slicing”（切片）。索引操作符 `[]` 中可以有一个、两个或者三个整数参数，如果有两个参数，需要用 `:` 隔开。它最终可以写成以下 5 种形式：\n",
     "\n",
     "> * `s[index]` —— 返回索引值为 `index` 的那个字符\n",
     "> * `s[start:]` —— 返回从索引值为 `start` 开始一直到字符串末尾的所有字符\n",
@@ -1778,6 +1778,9 @@
    "metadata": {
     "button": false,
     "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1880,6 +1883,9 @@
    "metadata": {
     "button": false,
     "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -1934,6 +1940,9 @@
    "metadata": {
     "button": false,
     "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
     "new_sheet": false,
     "run_control": {
      "read_only": false
@@ -2249,8 +2258,7 @@
     "new_sheet": false,
     "run_control": {
      "read_only": false
-    },
-    "scrolled": false
+    }
    },
    "outputs": [
     {
@@ -2748,10 +2756,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.10"
   },
   "toc-autonumbering": true
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Part.1.E.5.String - 1.6节：字符串的索引

原文：“索引操作符 `[]` 中可以有一个、两个或者三个整数参数，如果有两个参数，需要用 `:` 隔开。它最终可以写成以下 **4** 种形式：“ 实际一共罗列了5种形式。

因此，

”它最终可以写成以下 **4** 种形式“ ---> “它最终可以写成以下 **5** 种形式”