### PR TITLE
提交修改：更新 Jupyterlab两个插件的安装指南，修正了一些描述和命令格式

### DIFF
--- a/T-appendix.jupyter-installation-and-setup.ipynb
+++ b/T-appendix.jupyter-installation-and-setup.ipynb
@@ -303,7 +303,16 @@
     "> * [@jupyterlab/toc](https://github.com/jupyterlab/jupyterlab-toc)\n",
     "> * [ryantam626/jupyterlab_sublime](https://github.com/ryantam626/jupyterlab_sublime)\n",
     "\n",
-    "首先在用快捷键 `⌘ ,` 打开 jupyter lab 的 Advanced Settings，在 Extension Manager 中，添加 User Overrides：\n",
+    "如果JupyterLab 版本是 4.x ，jupyterlab-toc 已不用重新安装，因为这个插件已经被官方集成到 JupyterLab 4 里了；\n",
+    "\n",
+    "下面是安装jupyterlab_sublime的方法：\n",
+    " \n",
+    "首先如果JupyterLab 版本是 3.x 或 4.x，那么 Extension Manager 的设置方式和旧版本（如 2.x）不同，不再需要手动添加 \"enabled\": true：\n",
+    "\n",
+    "    用快捷键 `⌘ ,`打开 jupyter lab 的 Settings → Enable Extension Manager，直接勾选，系统会自动启用扩展管理功能；\n",
+    "\n",
+    "如果JupyterLab 版本是 2.x，\n",
+    "    用快捷键 `⌘ ,`打开 jupyter lab 的 Advanced Settings，在 Extension Manager 中，添加 User Overrides：\n",
     "\n",
     "```json\n",
     "{\n",
@@ -313,11 +322,19 @@
     "\n",
     "而后在 Terminal 执行以下命令安装插件：\n",
     "\n",
-    "```bash \n",
-    "jupyter labextension install @jupyterlab/toc\n",
-    "jupyter labextension install @ryantam626/jupyterlab_sublime\n",
-    "jupyter lab build\n",
+    "如果JupyterLab 版本 JupyterLab >= 3, 执行 \n",
+    "\n",
+    "```bash\n",
+    "pip install jupyterlab_sublime\n",
     "```\n",
+    "\n",
+    "如果JupyterLab 版本JupyterLab < 3,执行\n",
+    "```bash\n",
+    "jupyter labextension install @ryantam626/jupyterlab_sublime\n",
+    "```\n",
+    "\n",
+    "且注意，如果JupyterLab 版本是 4.x， jupyter labextension install指令已废弃，要用 pip 或 conda 安装插件。\n",
+    "\n",
     "\n",
     "toc 插件，自动将 ipynb 文件中的标题转换成目录。\n",
     "\n",
@@ -655,7 +672,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -669,10 +686,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.11.5"
   },
   "toc-autonumbering": true
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
1、如果JupyterLab 版本是 4.x， jupyter labextension install指令已废弃，要用 pip 或 conda 安装插件。
2、如果JupyterLab 版本是 4.x，插件jupyterlab-toc已不需要格外安装，已经被官方集成到 JupyterLab 4 里了；
3、如果JupyterLab 版本是 3.x 或 4.x，Extension Manager的打开方式与原文略有变更，且设置方式不需要手动修改json文件，直接勾选就可以了；
4、插件 jupyterlab_sublime的安装指令，根据JupyterLab 的版本号略有不同（来源：原作者Git页面的说明）