### PR TITLE
study result 20250805. 修改rst2ipynb代码

### DIFF
--- a/Part.1.G.The-Python-Tutorial-local.ipynb
+++ b/Part.1.G.The-Python-Tutorial-local.ipynb
@@ -235,7 +235,7 @@
     "cd ~/Downloads/cpython/Doc/tutorial/ \n",
     "for f in *.rst\n",
     "    do\n",
-    "        rst2ipynb $f -o ${f/%.rst/.ipynb}\n",
+    "        rst2ipynb $f > ${f/%.rst/.ipynb}\n",
     "    done\n",
     "mkdir ipynbs\n",
     "mv *.ipynb ipynbs/"
@@ -410,7 +410,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -424,10 +424,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.13.5"
   },
   "toc-autonumbering": true
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
'-o' 参数不起作用，无法生成 .ipynb 文件，使用'>'使用shell 重定向输出，可以完成转换